### PR TITLE
java 1.7 dependency fix

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: RustyCage; singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.baksia.rustycage.Activator
 Bundle-Vendor: org.baksia
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.jface,
  org.eclipse.ui.workbench,


### PR DESCRIPTION
There is one line of code that depends on Java 1.7, but the Bundle-RequiredExecutionEnvironment was only set to require 1.6. This meant that running it as an eclipse plugin project and spawning a new instance of Eclipse would work, but exporting it would fail.

Either you should accept this pull request, or else modify this one piece of code to work with 1.6:
 ERROR in /home/tupshin/workspaces/rust/RustyCage/src/org/baksia/rustycage/editors/RustEditStrategy.java (at line 24)
    switch (command.text) {
            ^^^^^^^^^^^^
Cannot switch on a value of type String for source level below 1.7. Only convertible int values or enum variables are permitted
